### PR TITLE
redirect page to blog

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -1,17 +1,19 @@
 import React from "react";
 import Layout from "@theme/Layout";
-import styles from "../css/style.module.css";
-import { ProfileSection } from "../components/ProfileSection";
-import { PersonnalitySection } from "../components/PersonnalitySection";
-import { SummarySkillsSection } from "../components/SummarySkillsSection";
-import { ExperienceSection } from "../components/ExperienceSection";
-import { TechnicalSkillsSection } from "../components/TechnicalSkillsSection";
-import HeaderSection from "../components/HeaderSection";
+import { Redirect } from "@docusaurus/router";
+// import styles from "../css/style.module.css";
+// import { ProfileSection } from "../components/ProfileSection";
+// import { PersonnalitySection } from "../components/PersonnalitySection";
+// import { SummarySkillsSection } from "../components/SummarySkillsSection";
+// import { ExperienceSection } from "../components/ExperienceSection";
+// import { TechnicalSkillsSection } from "../components/TechnicalSkillsSection";
+// import HeaderSection from "../components/HeaderSection";
 
 export default function PierreArnaudCV() {
   return (
     <Layout>
-      <HeaderSection />
+      <Redirect to="blog" />
+      {/* <HeaderSection />
       <div className={styles.page}>
         <div className={styles.container}>
           <div className={styles.columnLarge}>
@@ -24,7 +26,7 @@ export default function PierreArnaudCV() {
             <ExperienceSection />
           </div>
         </div>
-      </div>
+      </div> */}
     </Layout>
   );
 }


### PR DESCRIPTION
This pull request modifies the `website/src/pages/index.tsx` file to redirect the main page to the "blog" section instead of rendering the CV sections. It comments out the previously imported components and their usage in the page layout.

Key changes:

### Redirect implementation:
* Replaced the `HeaderSection` component with a `<Redirect>` element to redirect users to the "blog" page. (`[website/src/pages/index.tsxL3-R16](diffhunk://#diff-4a20f565abf6cd0f0a29097876c0510d592bb7ec38a8eb8d4170ea2ed382255cL3-R16)`)

### Code cleanup:
* Commented out imports for unused components (`ProfileSection`, `PersonnalitySection`, `SummarySkillsSection`, `ExperienceSection`, `TechnicalSkillsSection`, and `HeaderSection`) and their corresponding JSX elements in the layout. (`[[1]](diffhunk://#diff-4a20f565abf6cd0f0a29097876c0510d592bb7ec38a8eb8d4170ea2ed382255cL3-R16)`, `[[2]](diffhunk://#diff-4a20f565abf6cd0f0a29097876c0510d592bb7ec38a8eb8d4170ea2ed382255cL27-R29)`)